### PR TITLE
Patch makefile soname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # Makefile to build the aed water quality library
 # with hydrodynamic driver wrapper
 #
-
-VERS=3.0.0
+SOVERS=1
+VERS=3.0
 
 objdir=obj
 srcdir=src
@@ -26,7 +26,7 @@ ifeq ($(OSTYPE),Darwin)
   SHARED=-dynamiclib -undefined dynamic_lookup
   so_ext=dylib
 else
-  SHARED=-shared
+  SHARED=-shared -Wl,-soname,$(OUTLIB).so.$(SOVERS)
   so_ext=so
 endif
 
@@ -133,8 +133,9 @@ endif
 	ranlib $@
 
 ${libdir}/${OUTLIB}.${so_ext}: ${libdir}/lib${LIBAEDFV}.a ${OBJECTS}
-	$(FC) ${SHARED} -o $@.${VERS} ${OBJECTS} ${LDFLAGS} ${SOFLAGS}
-	ln -sf ${OUTLIB}.${so_ext}.${VERS} $@
+	$(FC) ${SHARED} -o $@.${SOVERS}.${VERS} ${OBJECTS} ${LDFLAGS} ${SOFLAGS}
+	ln -sf ${OUTLIB}.${so_ext}.${SOVERS}.${VERS} $@
+	ln -sf ${OUTLIB}.${so_ext}.${SOVERS}.${VERS} $@.${SOVERS}
 
 ${objdir}/%.o: ${srcdir}/%.F90 ${AEDWATDIR}/include/aed.h
 	$(F90) ${FFLAGS} ${INCLUDES} -g -c $< -o $@


### PR DESCRIPTION
TUFLOW FV requires that tuflowfv_external_wq.so is compiled with a compatible so version, i.e. tuflowfv_external_turb.so.1. 