### PR TITLE
Suggested radiation split and lpar modifier

### DIFF
--- a/src/fv_aed.F90
+++ b/src/fv_aed.F90
@@ -1343,13 +1343,18 @@ SUBROUTINE do_aed_models(nCells, nCols)
       CALL check_states(top, bot)
 
       !# populate local light/extc arrays one column at a time
-      IF (.NOT. link_ext_par) &  !#MH check link_ext_par logic
+      IF (.NOT. link_ext_par)  THEN !#MH check link_ext_par logic
          CALL Light(column, bot-top+1, I_0(col), extcoeff(top:bot), par(top:bot), h(top:bot))
+         !# non-PAR light fudge
+         nir(top:bot) = (par(top:bot)/0.43) * 0.520
+         uva(top:bot) = (par(top:bot)/0.43) * 0.048
+         uvb(top:bot) = (par(top:bot)/0.43) * 0.002
+      ELSE
+         nir(top:bot) = (lpar(top:bot)/0.43) * 0.520
+         uva(top:bot) = (lpar(top:bot)/0.43) * 0.048
+         uvb(top:bot) = (lpar(top:bot)/0.43) * 0.002
+      END IF
 
-      !# non-PAR light fudge
-      nir(top:bot) = (par(top:bot)/0.45) * 0.510
-      uva(top:bot) = (par(top:bot)/0.45) * 0.035
-      uvb(top:bot) = (par(top:bot)/0.45) * 0.005
    ENDDO
 !!$OMP END DO
 

--- a/src/fv_zones.F90
+++ b/src/fv_zones.F90
@@ -249,9 +249,9 @@ SUBROUTINE calc_zone_areas(nCols, active, temp, salt, h, area, wnd, rho,       &
    zone_par  =  zone_par / zone_count
 
    !# non-PAR light fudge
-   zone_nir = (zone_par/0.45) * 0.510
-   zone_uva = (zone_par/0.45) * 0.035
-   zone_uvb = (zone_par/0.45) * 0.005
+   zone_nir = (zone_par/0.43) * 0.520
+   zone_uva = (zone_par/0.43) * 0.048
+   zone_uvb = (zone_par/0.43) * 0.002
 
    zone_wind     =     zone_wind / zone_count
    zone_rain     =     zone_rain / zone_count


### PR DESCRIPTION
Hi Matt

Here is the radiation split we discussed as a pull request. It was pretty close, as we thought. And just for my memory.....the other thing that is affected by this split is photolysis, which is more likely to be switched on by typical users.

I have also suggested a modification to the logic of the calculation of nir, uva and uvb. It looks to me that if use_external_par is true, then nir, uva and uvb were being calculated as proportions of par(:), which was zero because lpar(:) is used when external PAR is switched on. I guess that if this is the case (big if!) then nir, uva and uvb were not reaching the pathogens module as anything non-zero, when external PAR was being used.  It might also be useful to add diagnostics to the pathogen module that reports back uva and uvb, just so the user is sure that the right fields are being carried through? Those diags would mirror the PAR diag in the phyto module I guess.

I've also suggested a change in the zones code, but have not tracked this down fully - there may be more changes required if zone_par was also being calculated from par and not lpar, when use_external_par is true.

MB